### PR TITLE
chore(deps): actualizar Spring Boot 3.4.3 y SpringDoc 2.8.5 (#46)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.2</version>
+        <version>3.4.3</version>
         <relativePath/>
         <!-- lookup parent from repository -->
     </parent>
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.8.4</version>
+            <version>2.8.5</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
* spring-boot-starter-parent: 3.4.2 -> 3.4.3
* springdoc-openapi-starter-webmvc-ui: 2.8.4 -> 2.8.5

Closes #46