### PR TITLE
release(v1.10.1): refactor y fix en AnotadorController y AnotadorService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.10.1] - 2026-05-12
+- refactor: Reemplazo de @Autowired con Lombok @RequiredArgsConstructor en AnotadorController (basado en análisis de git diff HEAD)
+- fix: Agregadas verificaciones de nulidad para ipVisado y respuesta en AnotadorService.add() para prevenir NullPointerException (basado en análisis de git diff HEAD)
+
 ## [1.10.0] - 2026-05-11
 - chore: Actualización de Spring Boot de 4.0.5 a 4.0.6 (basado en análisis de git diff HEAD y pom.xml)
 - chore: Actualización de Kotlin de 2.3.20 a 2.3.21 (basado en análisis de git diff HEAD y pom.xml)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Servicio central de liquidaciones de haberes de la Universidad de Mendoza. Permi
 
 ## Versión
 
-**1.10.0** (2026-05-11)
+**1.10.1** (2026-05-12)
 _La versión se corresponde con la declarada en `pom.xml`._
 
 ## Tecnologías y dependencias principales

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>ar.edu</groupId>
     <artifactId>um.haberes.core-service</artifactId>
-    <version>1.10.0</version>
+    <version>1.10.1</version>
     <name>UM.haberes.core-service</name>
     <description>Spring Boot Haberes</description>
     <properties>

--- a/src/main/java/um/haberes/core/controller/AnotadorController.java
+++ b/src/main/java/um/haberes/core/controller/AnotadorController.java
@@ -5,6 +5,7 @@ package um.haberes.core.controller;
 
 import java.util.List;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -27,10 +28,10 @@ import um.haberes.core.service.AnotadorService;
  */
 @RestController
 @RequestMapping("/api/haberes/core/anotador")
+@RequiredArgsConstructor
 public class AnotadorController {
 
-	@Autowired
-	private AnotadorService service;
+	private final AnotadorService service;
 
 	@GetMapping("/legajo/{legajoId}")
 	public ResponseEntity<List<Anotador>> findAllByLegajo(@PathVariable Long legajoId) {

--- a/src/main/java/um/haberes/core/service/AnotadorService.java
+++ b/src/main/java/um/haberes/core/service/AnotadorService.java
@@ -90,6 +90,12 @@ public class AnotadorService {
 	}
 
 	public Anotador add(Anotador anotador) {
+		if (anotador.getIpVisado() == null) {
+			anotador.setIpVisado("");
+		}
+		if (anotador.getRespuesta() == null) {
+			anotador.setRespuesta("");
+		}
 		repository.save(anotador);
 		return anotador;
 	}


### PR DESCRIPTION
Closes #88

## Descripción

Actualización a versión **1.10.1** que incluye un refactor y una corrección de bug en los módulos de Anotador.

## Cambios Realizados

- **Versionado**: pom.xml actualizado de `1.10.0` a `1.10.1`; CHANGELOG.md y README.md reflejan la nueva versión.
- **Refactor**: Reemplazo de inyección por `@Autowired` con Lombok `@RequiredArgsConstructor` e inyección por constructor (`private final`) en `AnotadorController.java`.
- **Bugfix**: Agregadas verificaciones de nulidad para `ipVisado` y `respuesta` en `AnotadorService.add()` para prevenir `NullPointerException`.

## Verificación

- [ ] Compilación exitosa con `mvn clean compile`
- [ ] Pruebas unitarias pasan con `mvn test`
- [ ] No se identifican breaking changes ni impacto en APIs existentes
