### PR TITLE
feat(geografica): add batch endpoint, migrate to Optional and Jsonifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## [1.11.0] - 2026-05-13
+- feat: Nuevo endpoint `POST /api/geograficas/ids` en GeograficaController para consulta batch de geográficas por IDs múltiples (basado en análisis de `git diff HEAD`)
+- feat: Nuevo use case `GetGeograficasByIdsUseCase` con implementación para búsqueda masiva vía `findAllIn` en GeograficaRepository (basado en análisis de `git diff HEAD`)
+- refactor: Renombrados métodos en módulo hexagonal Geografica (`getAll`→`getAllGeograficas`, `getById`→`getGeograficaById`, `update`→`updateGeografica`) para consistencia de API (basado en análisis de `git diff HEAD`)
+- refactor: Cambiados tipos de retorno a `Optional<Geografica>` en repositorio, casos de uso, servicio y adaptador de Geografica para manejo null-safe (basado en análisis de `git diff HEAD`)
+- refactor: Reemplazados lanzamientos de `GeograficaException` con `Optional.empty()` en `JpaGeograficaRepositoryAdapter.findById` y `update` (basado en análisis de `git diff HEAD`)
+- refactor: Reemplazados bloques `JsonMapper` try-catch con `Jsonifier` en `CursoCargoNovedadService` para logging de serialización más limpio (basado en análisis de `git diff HEAD`)
+- refactor: Agregado método `jsonify()` al modelo Kotlin `CursoCargoNovedad` (basado en análisis de `git diff HEAD`)
+- refactor: Agregada guarda de nulidad para campo `respuesta` en `CursoCargoNovedadService.add()` (basado en análisis de `git diff HEAD`)
+- refactor: Actualizado `MakeLiquidacionService.evaluateOnlyETEC` para usar `LiquidacionState` con contexto de cargos clase, corrigiendo evaluación ETEC-only basada en facultad (basado en análisis de `git diff HEAD`)
+- refactor: Agregado campo `cargoClases` a `LiquidacionState` y actualizadas referencias en `AfipContextService` (basado en análisis de `git diff HEAD`)
+- refactor: Reemplazado `@Autowired` con Lombok `@RequiredArgsConstructor` en `LiquidacionService`, `MakeLiquidacionService`, `DesignacionToolService`, `SheetService`, `AfipContextService` (basado en análisis de `git diff HEAD`)
+- refactor: Actualizado `DesignacionToolService` para usar `GeograficaService` hexagonal y `GeograficaMapper` en lugar de modelos Kotlin deprecados (basado en análisis de `git diff HEAD`)
+- refactor: Actualizados `ContratadoService` y `SheetService` para usar nuevos nombres de métodos del servicio hexagonal (basado en análisis de `git diff HEAD`)
+- refactor: Simplificado `ResponseEntity` en `CursoCargoNovedadController` usando `ResponseEntity.ok()` (basado en análisis de `git diff HEAD`)
+
 ## [1.10.1] - 2026-05-12
 - refactor: Reemplazo de @Autowired con Lombok @RequiredArgsConstructor en AnotadorController (basado en análisis de git diff HEAD)
 - fix: Agregadas verificaciones de nulidad para ipVisado y respuesta en AnotadorService.add() para prevenir NullPointerException (basado en análisis de git diff HEAD)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Servicio central de liquidaciones de haberes de la Universidad de Mendoza. Permi
 
 ## Versión
 
-**1.10.1** (2026-05-12)
+**1.11.0** (2026-05-13)
 _La versión se corresponde con la declarada en `pom.xml`._
 
 ## Tecnologías y dependencias principales

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>ar.edu</groupId>
     <artifactId>um.haberes.core-service</artifactId>
-    <version>1.10.1</version>
+    <version>1.11.0</version>
     <name>UM.haberes.core-service</name>
     <description>Spring Boot Haberes</description>
     <properties>

--- a/src/main/java/um/haberes/core/controller/CursoCargoNovedadController.java
+++ b/src/main/java/um/haberes/core/controller/CursoCargoNovedadController.java
@@ -167,7 +167,7 @@ public class CursoCargoNovedadController {
 
 	@PostMapping("/")
 	public ResponseEntity<CursoCargoNovedad> add(@RequestBody CursoCargoNovedad cursoCargoNovedad) {
-		return new ResponseEntity<>(service.add(cursoCargoNovedad), HttpStatus.OK);
+		return ResponseEntity.ok(service.add(cursoCargoNovedad));
 	}
 
 	@PutMapping("/{cursoCargoNovedadId}")

--- a/src/main/java/um/haberes/core/hexagonal/geografica/application/service/GeograficaService.java
+++ b/src/main/java/um/haberes/core/hexagonal/geografica/application/service/GeograficaService.java
@@ -1,29 +1,38 @@
 package um.haberes.core.hexagonal.geografica.application.service;
 
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 import um.haberes.core.hexagonal.geografica.domain.model.Geografica;
 import um.haberes.core.hexagonal.geografica.domain.ports.in.*;
+import um.haberes.core.hexagonal.geografica.domain.ports.out.GeograficaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class GeograficaService {
 
-    private final GetGeograficaByIdUseCase getGeograficaByIdUseCase;
+    private final GeograficaRepository geograficaRepository;
+
     private final GetAllGeograficasUseCase getAllGeograficasUseCase;
+    private final GetGeograficaByIdUseCase getGeograficaByIdUseCase;
+    private final GetGeograficasByIdsUseCase getGeograficasByIdsUseCase;
     private final UpdateGeograficaUseCase updateGeograficaUseCase;
 
-    public Geografica getGeograficaById(Integer id) {
-        return getGeograficaByIdUseCase.getById(id);
-    }
-
     public List<Geografica> getAllGeograficas() {
-        return getAllGeograficasUseCase.getAll();
+        return getAllGeograficasUseCase.getAllGeograficas();
     }
 
-    public Geografica updateGeografica(Integer id, Geografica geografica) {
-        return updateGeograficaUseCase.update(id, geografica);
+    public Optional<Geografica> getGeograficaById(Integer id) {
+        return getGeograficaByIdUseCase.getGeograficaById(id);
+    }
+
+    public List<Geografica> getGeograficasByIds(List<Integer> ids) {
+        return getGeograficasByIdsUseCase.getGeograficasByIds(ids);
+    }
+
+    public Optional<Geografica> updateGeografica(Integer id, Geografica geografica) {
+        return updateGeograficaUseCase.updateGeografica(id, geografica);
     }
 }

--- a/src/main/java/um/haberes/core/hexagonal/geografica/application/usecases/GetAllGeograficasUseCaseImpl.java
+++ b/src/main/java/um/haberes/core/hexagonal/geografica/application/usecases/GetAllGeograficasUseCaseImpl.java
@@ -1,13 +1,21 @@
 package um.haberes.core.hexagonal.geografica.application.usecases;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
+
 import um.haberes.core.hexagonal.geografica.domain.model.Geografica;
 import um.haberes.core.hexagonal.geografica.domain.ports.in.GetAllGeograficasUseCase;
 import um.haberes.core.hexagonal.geografica.domain.ports.out.GeograficaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
+
 @Component
 @RequiredArgsConstructor
 public class GetAllGeograficasUseCaseImpl implements GetAllGeograficasUseCase {
-    private final GeograficaRepository repository;
-    @Override public List<Geografica> getAll() { return repository.findAll(); }
+
+    private final GeograficaRepository geograficaRepository;
+
+    @Override
+    public List<Geografica> getAllGeograficas() {
+        return geograficaRepository.findAll();
+    }
 }

--- a/src/main/java/um/haberes/core/hexagonal/geografica/application/usecases/GetGeograficaByIdUseCaseImpl.java
+++ b/src/main/java/um/haberes/core/hexagonal/geografica/application/usecases/GetGeograficaByIdUseCaseImpl.java
@@ -1,13 +1,21 @@
 package um.haberes.core.hexagonal.geografica.application.usecases;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
+
 import um.haberes.core.hexagonal.geografica.domain.model.Geografica;
 import um.haberes.core.hexagonal.geografica.domain.ports.in.GetGeograficaByIdUseCase;
 import um.haberes.core.hexagonal.geografica.domain.ports.out.GeograficaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
 import java.util.Optional;
+
 @Component
 @RequiredArgsConstructor
 public class GetGeograficaByIdUseCaseImpl implements GetGeograficaByIdUseCase {
-    private final GeograficaRepository repository;
-    @Override public Geografica getById(Integer id) { return repository.findById(id); }
+
+    private final GeograficaRepository geograficaRepository;
+
+    @Override
+    public Optional<Geografica> getGeograficaById(Integer id) {
+        return geograficaRepository.findById(id);
+    }
 }

--- a/src/main/java/um/haberes/core/hexagonal/geografica/application/usecases/GetGeograficasByIdsUseCaseImpl.java
+++ b/src/main/java/um/haberes/core/hexagonal/geografica/application/usecases/GetGeograficasByIdsUseCaseImpl.java
@@ -1,21 +1,21 @@
 package um.haberes.core.hexagonal.geografica.application.usecases;
 
 import um.haberes.core.hexagonal.geografica.domain.model.Geografica;
-import um.haberes.core.hexagonal.geografica.domain.ports.in.UpdateGeograficaUseCase;
+import um.haberes.core.hexagonal.geografica.domain.ports.in.GetGeograficasByIdsUseCase;
 import um.haberes.core.hexagonal.geografica.domain.ports.out.GeograficaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.util.Optional;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
-public class UpdateGeograficaUseCaseImpl implements UpdateGeograficaUseCase {
+public class GetGeograficasByIdsUseCaseImpl implements GetGeograficasByIdsUseCase {
 
     private final GeograficaRepository geograficaRepository;
 
     @Override
-    public Optional<Geografica> updateGeografica(Integer id, Geografica geografica) {
-        return geograficaRepository.update(id, geografica);
+    public List<Geografica> getGeograficasByIds(List<Integer> ids) {
+        return geograficaRepository.findAllIn(ids);
     }
 }

--- a/src/main/java/um/haberes/core/hexagonal/geografica/domain/model/Geografica.java
+++ b/src/main/java/um/haberes/core/hexagonal/geografica/domain/model/Geografica.java
@@ -1,12 +1,12 @@
 package um.haberes.core.hexagonal.geografica.domain.model;
 
-import lombok.*;
-
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 
-@Setter
+import lombok.*;
+
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/um/haberes/core/hexagonal/geografica/domain/ports/in/GetAllGeograficasUseCase.java
+++ b/src/main/java/um/haberes/core/hexagonal/geografica/domain/ports/in/GetAllGeograficasUseCase.java
@@ -1,4 +1,8 @@
 package um.haberes.core.hexagonal.geografica.domain.ports.in;
+
 import um.haberes.core.hexagonal.geografica.domain.model.Geografica;
 import java.util.List;
-public interface GetAllGeograficasUseCase { List<Geografica> getAll(); }
+
+public interface GetAllGeograficasUseCase {
+    List<Geografica> getAllGeograficas();
+}

--- a/src/main/java/um/haberes/core/hexagonal/geografica/domain/ports/in/GetGeograficasByIdsUseCase.java
+++ b/src/main/java/um/haberes/core/hexagonal/geografica/domain/ports/in/GetGeograficasByIdsUseCase.java
@@ -1,8 +1,8 @@
 package um.haberes.core.hexagonal.geografica.domain.ports.in;
 
 import um.haberes.core.hexagonal.geografica.domain.model.Geografica;
-import java.util.Optional;
+import java.util.List;
 
-public interface GetGeograficaByIdUseCase {
-    Optional<Geografica> getGeograficaById(Integer id);
+public interface GetGeograficasByIdsUseCase {
+    List<Geografica> getGeograficasByIds(List<Integer> ids);
 }

--- a/src/main/java/um/haberes/core/hexagonal/geografica/domain/ports/in/UpdateGeograficaUseCase.java
+++ b/src/main/java/um/haberes/core/hexagonal/geografica/domain/ports/in/UpdateGeograficaUseCase.java
@@ -4,5 +4,5 @@ import um.haberes.core.hexagonal.geografica.domain.model.Geografica;
 import java.util.Optional;
 
 public interface UpdateGeograficaUseCase {
-    Geografica update(Integer id, Geografica geografica);
+    Optional<Geografica> updateGeografica(Integer id, Geografica geografica);
 }

--- a/src/main/java/um/haberes/core/hexagonal/geografica/domain/ports/out/GeograficaRepository.java
+++ b/src/main/java/um/haberes/core/hexagonal/geografica/domain/ports/out/GeograficaRepository.java
@@ -6,9 +6,9 @@ import java.util.Optional;
 
 public interface GeograficaRepository {
     Geografica create(Geografica geografica);
-    Geografica findById(Integer id);
+    Optional<Geografica> findById(Integer id);
     List<Geografica> findAll();
     List<Geografica> findAllIn(List<Integer> ids);
-    Geografica update(Integer id, Geografica geografica);
+    Optional<Geografica> update(Integer id, Geografica geografica);
     boolean deleteById(Integer id);
 }

--- a/src/main/java/um/haberes/core/hexagonal/geografica/infrastructure/persistence/adapter/JpaGeograficaRepositoryAdapter.java
+++ b/src/main/java/um/haberes/core/hexagonal/geografica/infrastructure/persistence/adapter/JpaGeograficaRepositoryAdapter.java
@@ -1,13 +1,12 @@
 package um.haberes.core.hexagonal.geografica.infrastructure.persistence.adapter;
 
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
-import um.haberes.core.exception.GeograficaException;
 import um.haberes.core.hexagonal.geografica.domain.model.Geografica;
 import um.haberes.core.hexagonal.geografica.domain.ports.out.GeograficaRepository;
 import um.haberes.core.hexagonal.geografica.infrastructure.persistence.entity.GeograficaEntity;
 import um.haberes.core.hexagonal.geografica.infrastructure.persistence.mapper.GeograficaMapper;
 import um.haberes.core.hexagonal.geografica.infrastructure.persistence.repository.JpaGeograficaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Optional;
@@ -28,10 +27,9 @@ public class JpaGeograficaRepositoryAdapter implements GeograficaRepository {
     }
 
     @Override
-    public Geografica findById(Integer id) {
+    public Optional<Geografica> findById(Integer id) {
         return jpaGeograficaRepository.findById(id)
-                .map(geograficaMapper::toDomainModel)
-                .orElseThrow(() -> new GeograficaException(id));
+                .map(geograficaMapper::toDomainModel);
     }
 
     @Override
@@ -49,14 +47,14 @@ public class JpaGeograficaRepositoryAdapter implements GeograficaRepository {
     }
 
     @Override
-    public Geografica update(Integer id, Geografica geografica) {
+    public Optional<Geografica> update(Integer id, Geografica geografica) {
         if (jpaGeograficaRepository.existsById(id)) {
             GeograficaEntity entity = geograficaMapper.toEntity(geografica);
             entity.setGeograficaId(id); // Ensure the ID is set for update
             GeograficaEntity updatedEntity = jpaGeograficaRepository.save(entity);
-            return geograficaMapper.toDomainModel(updatedEntity);
+            return Optional.of(geograficaMapper.toDomainModel(updatedEntity));
         }
-        throw new GeograficaException(id);
+        return Optional.empty();
     }
 
     @Override

--- a/src/main/java/um/haberes/core/hexagonal/geografica/infrastructure/persistence/mapper/GeograficaMapper.java
+++ b/src/main/java/um/haberes/core/hexagonal/geografica/infrastructure/persistence/mapper/GeograficaMapper.java
@@ -1,8 +1,8 @@
 package um.haberes.core.hexagonal.geografica.infrastructure.persistence.mapper;
 
-import org.springframework.stereotype.Component;
 import um.haberes.core.hexagonal.geografica.domain.model.Geografica;
 import um.haberes.core.hexagonal.geografica.infrastructure.persistence.entity.GeograficaEntity;
+import org.springframework.stereotype.Component;
 
 @Component
 public class GeograficaMapper {

--- a/src/main/java/um/haberes/core/hexagonal/geografica/infrastructure/web/controller/GeograficaController.java
+++ b/src/main/java/um/haberes/core/hexagonal/geografica/infrastructure/web/controller/GeograficaController.java
@@ -1,16 +1,14 @@
 package um.haberes.core.hexagonal.geografica.infrastructure.web.controller;
 
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.web.server.ResponseStatusException;
-import um.haberes.core.exception.GeograficaException;
 import um.haberes.core.hexagonal.geografica.application.service.GeograficaService;
 import um.haberes.core.hexagonal.geografica.domain.model.Geografica;
 import um.haberes.core.hexagonal.geografica.infrastructure.web.dto.GeograficaRequest;
 import um.haberes.core.hexagonal.geografica.infrastructure.web.dto.GeograficaResponse;
 import um.haberes.core.hexagonal.geografica.infrastructure.web.mapper.GeograficaDtoMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -23,13 +21,11 @@ public class GeograficaController {
     private final GeograficaService geograficaService;
     private final GeograficaDtoMapper geograficaDtoMapper;
 
-    @GetMapping("/{geograficaId}")
-    public ResponseEntity<GeograficaResponse> getGeograficaById(@PathVariable Integer geograficaId) {
-        try {
-            return ResponseEntity.ok(geograficaDtoMapper.toResponse(geograficaService.getGeograficaById(geograficaId)));
-        } catch (GeograficaException e) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
-        }
+    @GetMapping("/{id}")
+    public ResponseEntity<GeograficaResponse> getGeograficaById(@PathVariable Integer id) {
+        return geograficaService.getGeograficaById(id)
+                .map(geografica -> new ResponseEntity<>(geograficaDtoMapper.toResponse(geografica), HttpStatus.OK))
+                .orElse(new ResponseEntity<>(HttpStatus.NOT_FOUND));
     }
 
     @GetMapping("/")
@@ -40,13 +36,19 @@ public class GeograficaController {
         return new ResponseEntity<>(responses, HttpStatus.OK);
     }
 
-    @PutMapping("/{geograficaId}")
-    public ResponseEntity<GeograficaResponse> updateGeografica(@PathVariable Integer geograficaId, @RequestBody GeograficaRequest request) {
+    @PostMapping("/ids")
+    public ResponseEntity<List<GeograficaResponse>> getGeograficasByIds(@RequestBody List<Integer> ids) {
+        List<GeograficaResponse> responses = geograficaService.getGeograficasByIds(ids).stream()
+                .map(geograficaDtoMapper::toResponse)
+                .collect(Collectors.toList());
+        return new ResponseEntity<>(responses, HttpStatus.OK);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<GeograficaResponse> updateGeografica(@PathVariable Integer id, @RequestBody GeograficaRequest request) {
         Geografica domain = geograficaDtoMapper.toDomain(request);
-        try {
-            return ResponseEntity.ok(geograficaDtoMapper.toResponse(geograficaService.updateGeografica(geograficaId, domain)));
-        } catch (GeograficaException e) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
-        }
+        return geograficaService.updateGeografica(id, domain)
+                .map(updated -> new ResponseEntity<>(geograficaDtoMapper.toResponse(updated), HttpStatus.OK))
+                .orElse(new ResponseEntity<>(HttpStatus.NOT_FOUND));
     }
 }

--- a/src/main/java/um/haberes/core/hexagonal/geografica/infrastructure/web/dto/GeograficaRequest.java
+++ b/src/main/java/um/haberes/core/hexagonal/geografica/infrastructure/web/dto/GeograficaRequest.java
@@ -1,7 +1,15 @@
 package um.haberes.core.hexagonal.geografica.infrastructure.web.dto;
+
+import lombok.Builder;
 import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
 import java.math.BigDecimal;
-@Data
+
+@Getter
+@Setter
+@Builder
 public class GeograficaRequest {
     private String nombre;
     private String reducido;

--- a/src/main/java/um/haberes/core/hexagonal/geografica/infrastructure/web/dto/GeograficaResponse.java
+++ b/src/main/java/um/haberes/core/hexagonal/geografica/infrastructure/web/dto/GeograficaResponse.java
@@ -1,12 +1,15 @@
 package um.haberes.core.hexagonal.geografica.infrastructure.web.dto;
-import lombok.*;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.math.BigDecimal;
+
 @Getter
 @Setter
 @Builder
-@NoArgsConstructor
-@AllArgsConstructor
 public class GeograficaResponse {
     private Integer geograficaId;
     private String nombre;

--- a/src/main/java/um/haberes/core/hexagonal/geografica/infrastructure/web/mapper/GeograficaDtoMapper.java
+++ b/src/main/java/um/haberes/core/hexagonal/geografica/infrastructure/web/mapper/GeograficaDtoMapper.java
@@ -1,9 +1,9 @@
 package um.haberes.core.hexagonal.geografica.infrastructure.web.mapper;
 
-import org.springframework.stereotype.Component;
 import um.haberes.core.hexagonal.geografica.domain.model.Geografica;
 import um.haberes.core.hexagonal.geografica.infrastructure.web.dto.GeograficaRequest;
 import um.haberes.core.hexagonal.geografica.infrastructure.web.dto.GeograficaResponse;
+import org.springframework.stereotype.Component;
 
 @Component
 public class GeograficaDtoMapper {

--- a/src/main/java/um/haberes/core/kotlin/model/CursoCargoNovedad.kt
+++ b/src/main/java/um/haberes/core/kotlin/model/CursoCargoNovedad.kt
@@ -1,6 +1,7 @@
 package um.haberes.core.kotlin.model
 
 import jakarta.persistence.*
+import um.haberes.core.util.Jsonifier
 import java.math.BigDecimal
 
 @Entity
@@ -39,4 +40,8 @@ data class CursoCargoNovedad(
     @JoinColumn(name = "legajoId", insertable = false, updatable = false)
     var persona: Persona? = null
 
-) : Auditable()
+) : Auditable() {
+    fun jsonify(): String {
+        return Jsonifier.builder(this).build();
+    }
+}

--- a/src/main/java/um/haberes/core/service/CursoCargoNovedadService.java
+++ b/src/main/java/um/haberes/core/service/CursoCargoNovedadService.java
@@ -3,6 +3,7 @@
  */
 package um.haberes.core.service;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -19,6 +20,7 @@ import org.springframework.stereotype.Service;
 import um.haberes.core.exception.CursoCargoNovedadException;
 import um.haberes.core.kotlin.model.CursoCargoNovedad;
 import um.haberes.core.repository.CursoCargoNovedadRepository;
+import um.haberes.core.util.Jsonifier;
 
 /**
  * @author daniel
@@ -41,11 +43,7 @@ public class CursoCargoNovedadService {
 						Sort.by("persona.apellido").ascending().and(Sort.by("persona.nombre").ascending())
 								.and(Sort.by("cargoTipo.aCargo").descending()).and(Sort.by("cargoTipoId").ascending()))
 				.stream().filter(cargo -> cargo.getAlta() == 1 || cargo.getCambio() == 1).collect(Collectors.toList());
-        try {
-            log.debug("PendientesAlta: {}", JsonMapper.builder().findAndAddModules().build().writerWithDefaultPrettyPrinter().writeValueAsString(pendientesAlta));
-        } catch (JsonProcessingException e) {
-            log.debug("PendientesAlta: {}", e.getMessage());
-        }
+		log.debug("pendientesAlta -> {}", Jsonifier.builder(pendientesAlta).build());
         return pendientesAlta;
 	}
 
@@ -82,11 +80,7 @@ public class CursoCargoNovedadService {
 		var pendientesBaja = repository.findAllByAnhoAndMesAndBajaAndAutorizadoAndRechazado(anho, mes, (byte) 1, (byte) 0, (byte) 0,
 				Sort.by("persona.apellido").ascending().and(Sort.by("persona.nombre").ascending())
 						.and(Sort.by("cargoTipo.aCargo").descending()).and(Sort.by("cargoTipoId").ascending()));
-        try {
-            log.debug("PendientesBaja: {}", JsonMapper.builder().findAndAddModules().build().writerWithDefaultPrettyPrinter().writeValueAsString(pendientesBaja));
-        } catch (JsonProcessingException e) {
-            log.debug("PendientesBaja: {}", e.getMessage());
-        }
+		log.debug("pendientesBaja -> {}",  Jsonifier.builder(pendientesBaja).build());
         return pendientesBaja;
 	}
 
@@ -118,11 +112,7 @@ public class CursoCargoNovedadService {
 	public List<CursoCargoNovedad> findAllPendientesLegajo(Long legajoId, Long cursoId, Integer anho, Integer mes) {
 		var pendientesLegajo = repository.findAllByCursoIdAndAnhoAndMesAndAutorizadoAndRechazadoAndLegajoId(cursoId, anho, mes,
 				(byte) 0, (byte) 0, legajoId);
-        try {
-            log.debug("PendientesLegajo: {}", JsonMapper.builder().findAndAddModules().build().writerWithDefaultPrettyPrinter().writeValueAsString(pendientesLegajo));
-        } catch (JsonProcessingException e) {
-            log.debug("PendientesLegajo: {}", e.getMessage());
-        }
+		log.debug("pendientesLegajo -> {}", Jsonifier.builder(pendientesLegajo).build());
         return pendientesLegajo;
 	}
 
@@ -145,48 +135,31 @@ public class CursoCargoNovedadService {
 	public CursoCargoNovedad findByCursoCargoNovedadId(Long cursoCargoNovedadId) {
 		var cursoCargoNovedad = repository.findByCursoCargoNovedadId(cursoCargoNovedadId)
 				.orElseThrow(() -> new CursoCargoNovedadException(cursoCargoNovedadId));
-        try {
-            log.debug("CursoCargoNovedad -> " + JsonMapper.builder().findAndAddModules().build().writerWithDefaultPrettyPrinter().writeValueAsString(cursoCargoNovedad));
-        } catch (JsonProcessingException e) {
-            log.debug("CursoCargoNovedad -> null {}", e.getMessage());
-        }
+		log.debug("CursoCargoNovedad -> {}",  cursoCargoNovedad.jsonify());
         return cursoCargoNovedad;
 	}
 
 	public CursoCargoNovedad findByLegajo(Long legajoId, Long cursoId, Integer anho, Integer mes) {
 		var cursoCargoNovedad = repository.findByLegajoIdAndCursoIdAndAnhoAndMes(legajoId, cursoId, anho, mes)
 				.orElseThrow(() -> new CursoCargoNovedadException(legajoId, cursoId, anho, mes));
-        try {
-            log.debug("CursoCargoNovedad -> " + JsonMapper.builder().findAndAddModules().build().writerWithDefaultPrettyPrinter().writeValueAsString(cursoCargoNovedad));
-        } catch (JsonProcessingException e) {
-            log.debug("CursoCargoNovedad -> null {}", e.getMessage());
-        }
+		log.debug("CursoCargoNovedad -> {}",  cursoCargoNovedad.jsonify());
         return cursoCargoNovedad;
 	}
 
 	public CursoCargoNovedad findByUnique(Long cursoId, Integer anho, Integer mes, Integer cargoTipoId, Long legajoId) {
 		var cursoCargoNovedad = repository.findByCursoIdAndAnhoAndMesAndCargoTipoIdAndLegajoId(cursoId, anho, mes, cargoTipoId, legajoId)
 				.orElseThrow(() -> new CursoCargoNovedadException(cursoId, anho, mes, cargoTipoId, legajoId));
-        try {
-            log.debug("CursoCargoNovedad -> " + JsonMapper.builder().findAndAddModules().build().writerWithDefaultPrettyPrinter().writeValueAsString(cursoCargoNovedad));
-        } catch (JsonProcessingException e) {
-            log.debug("CursoCargoNovedad -> null {}", e.getMessage());
-        }
+		log.debug("CursoCargoNovedad -> {}",  cursoCargoNovedad.jsonify());
         return cursoCargoNovedad;
 	}
 
 	public CursoCargoNovedad add(CursoCargoNovedad cursoCargoNovedad) {
-        try {
-            log.debug("CursoCargoNovedad (before) -> " + JsonMapper.builder().findAndAddModules().build().writerWithDefaultPrettyPrinter().writeValueAsString(cursoCargoNovedad));
-        } catch (JsonProcessingException e) {
-            log.debug("CursoCargoNovedad (before) -> null {}", e.getMessage());
-        }
+		if (cursoCargoNovedad.getRespuesta() == null) {
+			cursoCargoNovedad.setRespuesta("");
+		}
+		log.debug("CursoCargoNovedad (before) -> {}",  cursoCargoNovedad.jsonify());
         cursoCargoNovedad = repository.save(cursoCargoNovedad);
-        try {
-            log.debug("CursoCargoNovedad (after) -> " + JsonMapper.builder().findAndAddModules().build().writerWithDefaultPrettyPrinter().writeValueAsString(cursoCargoNovedad));
-        } catch (JsonProcessingException e) {
-            log.debug("CursoCargoNovedad (after) -> null {}", e.getMessage());
-        }
+		log.debug("CursoCargoNovedad (after) -> {}",  cursoCargoNovedad.jsonify());
 		return cursoCargoNovedad;
 	}
 

--- a/src/main/java/um/haberes/core/service/facade/DesignacionToolService.java
+++ b/src/main/java/um/haberes/core/service/facade/DesignacionToolService.java
@@ -321,7 +321,9 @@ public class DesignacionToolService {
             Curso curso = cursos.get(cursoCargo.getCursoId());
             Geografica geografica = geograficaMapper.toDomainModel(curso.getGeografica());
             if (persona.getReemplazoDesarraigo() == 1) {
-                geografica = geograficaService.getGeograficaById(geografica.getGeograficaIdReemplazo());
+                var geograficaId = geografica.getGeograficaIdReemplazo();
+                geografica = geograficaService.getGeograficaById(geograficaId)
+                        .orElseThrow(() -> new GeograficaException(geograficaId));
             }
             BigDecimal desarraigo = geografica.getDesarraigo();
             if (persona.getMitadDesarraigo() == 1) {


### PR DESCRIPTION
Closes #90

## Descripción

Release **v1.11.0** con nuevo endpoint batch de geográficas, migración a `Optional<Geografica>` para manejo null-safe, y migración de `JsonMapper` a `Jsonifier` en `CursoCargoNovedadService`.

## Cambios Realizados

- **Nuevo endpoint** `POST /api/geograficas/ids` para consulta batch de geográficas por IDs
- **Nuevos casos de uso** `GetGeograficasByIdsUseCase` e implementación con `findAllIn` en repositorio
- **Migración a `Optional<Geografica>`** en repositorio, casos de uso, servicio y controlador (eliminando throws `GeograficaException`)
- **Renombrado de métodos** en módulo hexagonal: `getAll` → `getAllGeograficas`, `getById` → `getGeograficaById`, `update` → `updateGeografica`
- **Migración a `Jsonifier`** en `CursoCargoNovedadService` reemplazando bloques try-catch de `JsonMapper`
- **Simplificación** de `ResponseEntity.ok()` en `CursoCargoNovedadController`
- **Null guard** para campo `respuesta` en `CursoCargoNovedadService.add()`
- **Adaptación** de `DesignacionToolService` al nuevo retorno `Optional` con `orElseThrow`
- **Bump de versión** `1.10.1` → `1.11.0` en `pom.xml`, `README.md` y `CHANGELOG.md`

## Verificación

- Compilación exitosa con `mvn clean compile`
- Pruebas unitarias: `mvn test`
- Prueba manual del endpoint `POST /api/geograficas/ids` con IDs válidos
- Verificar manejo de `Optional.empty()` en casos sin datos
- Validar serialización JSON con las nuevas anotaciones en DTOs
