### PR TITLE
chore(deps): actualizar dependencias y corregir compatibilidad con Java 25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [1.11.1] - 2026-06-19
+- chore: Actualización de Spring Boot de 4.0.6 a 4.1.0 (basado en `git diff HEAD` y `pom.xml`)
+- chore: Actualización de Kotlin de 2.3.21 a 2.4.0 (basado en `git diff HEAD` y `pom.xml`)
+- chore: Actualización de Spring Cloud de 2025.1.0 a 2025.1.2 (basado en `git diff HEAD` y `pom.xml`)
+- chore: Actualización de MySQL Connector/J de 9.6.0 a 9.7.0 (basado en `git diff HEAD` y `pom.xml`)
+- chore: Actualización de OpenPDF de 3.0.3 a 3.0.5 (basado en `git diff HEAD` y `pom.xml`)
+- chore: Actualización de springdoc-openapi de 3.0.2 a 3.0.3 (basado en `git diff HEAD` y `pom.xml`)
+- fix: Corregido patrón `@JsonFormat` de `Z` a `XX` en todas las entidades Kotlin con campos `OffsetDateTime` para compatibilidad con Java 25 (basado en `git diff HEAD` en 21 modelos)
+- refactor: Unboxing de `Integer`→`int` y `Boolean`→`boolean` en `NovedadFileService` para eliminar auto-boxing innecesario (basado en `git diff HEAD`)
+
 ## [1.11.0] - 2026-05-13
 - feat: Nuevo endpoint `POST /api/geograficas/ids` en GeograficaController para consulta batch de geográficas por IDs múltiples (basado en análisis de `git diff HEAD`)
 - feat: Nuevo use case `GetGeograficasByIdsUseCase` con implementación para búsqueda masiva vía `findAllIn` en GeograficaRepository (basado en análisis de `git diff HEAD`)

--- a/README.md
+++ b/README.md
@@ -5,24 +5,24 @@ Servicio central de liquidaciones de haberes de la Universidad de Mendoza. Permi
 
 ## Versión
 
-**1.11.0** (2026-05-13)
+**1.11.1** (2026-06-19)
 _La versión se corresponde con la declarada en `pom.xml`._
 
 ## Tecnologías y dependencias principales
 
 - Java 25
-- Kotlin 2.3.21
-- Spring Boot 4.0.6
-- Spring Cloud 2025.1.0 (OpenFeign, Consul)
+- Kotlin 2.4.0
+- Spring Boot 4.1.0
+- Spring Cloud 2025.1.2 (OpenFeign, Consul)
 - Spring Data JPA
 - Apache POI 5.5.1 (Excel)
-- OpenPDF 3.0.3 (PDF)
+- OpenPDF 3.0.5 (PDF)
 - Log4j2
 - Caffeine Cache
 - Jackson
-- MySQL Connector/J 9.6.0
+- MySQL Connector/J 9.7.0
 - Docker
-- Springdoc OpenAPI
+- Springdoc OpenAPI 3.0.3
 
 ## Diagramas principales
 
@@ -30,8 +30,8 @@ _La versión se corresponde con la declarada en `pom.xml`._
 - Flujo de liquidación de sueldos: `docs/diagrams/flujo-liquidacion-sueldos.mmd`
 - Modelo entidad-relación: `docs/diagrams/modelo-entidad-relacion.mmd`
 - Despliegue: `docs/diagrams/despliegue.mmd`
-- **Nuevo:** Flujo de liquidación general masiva: `docs/diagrams/flujo-liquidacion-general.mmd`
-- **Nuevo:** Flujo de LegajoBanco con filtro por código: `docs/diagrams/flujo-legajobanco-filtro-codigo.mmd`
+- Flujo de liquidación general masiva: `docs/diagrams/flujo-liquidacion-general.mmd`
+- Flujo de LegajoBanco con filtro por código: `docs/diagrams/flujo-legajobanco-filtro-codigo.mmd`
 
 ## Documentación automática
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,19 +5,19 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.6</version>
+        <version>4.1.0</version>
         <relativePath/>
         <!-- lookup parent from repository -->
     </parent>
     <groupId>ar.edu</groupId>
     <artifactId>um.haberes.core-service</artifactId>
-    <version>1.11.0</version>
+    <version>1.11.1</version>
     <name>UM.haberes.core-service</name>
     <description>Spring Boot Haberes</description>
     <properties>
         <java.version>25</java.version>
-        <kotlin.version>2.3.21</kotlin.version>
-        <spring-cloud.version>2025.1.0</spring-cloud.version>
+        <kotlin.version>2.4.0</kotlin.version>
+        <spring-cloud.version>2025.1.2</spring-cloud.version>
         <lombok.version>1.18.38</lombok.version>
         <sonar.organization>um-services</sonar.organization>
         <sonar.projectKey>UM-services_UM.haberes.core-service</sonar.projectKey>
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
-            <version>9.6.0</version>
+            <version>9.7.0</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>com.github.librepdf</groupId>
             <artifactId>openpdf</artifactId>
-            <version>3.0.3</version>
+            <version>3.0.5</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>3.0.2</version>
+            <version>3.0.3</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/um/haberes/core/kotlin/model/Acreditacion.kt
+++ b/src/main/java/um/haberes/core/kotlin/model/Acreditacion.kt
@@ -17,10 +17,10 @@ data class Acreditacion(
     var mes: Int = 0,
     var acreditado: Byte = 0,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var limiteNovedades: OffsetDateTime? = null,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaContable: OffsetDateTime? = null,
 
     var ordenContable: Int? = null,

--- a/src/main/java/um/haberes/core/kotlin/model/AcreditacionPago.kt
+++ b/src/main/java/um/haberes/core/kotlin/model/AcreditacionPago.kt
@@ -16,7 +16,7 @@ data class AcreditacionPago(
     var anho: Int = 0,
     var mes: Int = 0,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaPago: OffsetDateTime? = null,
     var totalSantander: BigDecimal = BigDecimal.ZERO,
     var totalOtrosBancos: BigDecimal = BigDecimal.ZERO,

--- a/src/main/java/um/haberes/core/kotlin/model/BonoImpresion.kt
+++ b/src/main/java/um/haberes/core/kotlin/model/BonoImpresion.kt
@@ -17,7 +17,7 @@ data class BonoImpresion(
     var mes: Int = 0,
     var legajoIdSolicitud: Long? = null,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fecha: OffsetDateTime? = null,
 
     var ipAddress: String = ""

--- a/src/main/java/um/haberes/core/kotlin/model/Cargo.kt
+++ b/src/main/java/um/haberes/core/kotlin/model/Cargo.kt
@@ -14,10 +14,10 @@ data class Cargo(
 
     var legajoId: Long? = null,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaAlta: OffsetDateTime? = null,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaBaja: OffsetDateTime? = null,
 
     var dependenciaId: Int? = null,

--- a/src/main/java/um/haberes/core/kotlin/model/CargoLiquidacion.kt
+++ b/src/main/java/um/haberes/core/kotlin/model/CargoLiquidacion.kt
@@ -15,9 +15,9 @@ data class CargoLiquidacion(
     var anho: Int? = null,
     var mes: Int? = null,
     var dependenciaId: Int? = null,
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaDesde: OffsetDateTime? = null,
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaHasta: OffsetDateTime? = null,
     var categoriaId: Int? = null,
     var categoriaNombre: String = "",

--- a/src/main/java/um/haberes/core/kotlin/model/CargoLiquidacionVersion.kt
+++ b/src/main/java/um/haberes/core/kotlin/model/CargoLiquidacionVersion.kt
@@ -24,10 +24,10 @@ data class CargoLiquidacionVersion(
     var jornada: Int = 0,
     var presentismo: Int = 0,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaDesde: OffsetDateTime? = null,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaHasta: OffsetDateTime? = null,
 
     var situacion: String? = null

--- a/src/main/java/um/haberes/core/kotlin/model/Control.kt
+++ b/src/main/java/um/haberes/core/kotlin/model/Control.kt
@@ -15,19 +15,19 @@ data class Control(
     var anho: Int? = null,
     var mes: Int? = null,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaDesde: OffsetDateTime? = null,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaHasta: OffsetDateTime? = null,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaPago: OffsetDateTime? = null,
 
     var aporteJubilatorio: String? = null,
     var depositoBanco: String? = null,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaDeposito: OffsetDateTime? = null,
 
     var doctorado: BigDecimal = BigDecimal.ZERO,

--- a/src/main/java/um/haberes/core/kotlin/model/Excluido.kt
+++ b/src/main/java/um/haberes/core/kotlin/model/Excluido.kt
@@ -16,7 +16,7 @@ data class Excluido(
     var anho: Int = 0,
     var mes: Int = 0,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fecha: OffsetDateTime? = null,
 
     var observaciones: String = ""

--- a/src/main/java/um/haberes/core/kotlin/model/Lectivo.kt
+++ b/src/main/java/um/haberes/core/kotlin/model/Lectivo.kt
@@ -15,10 +15,10 @@ data class Lectivo(
 
     var nombre: String = "",
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaInicio: OffsetDateTime? = null,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaFinal: OffsetDateTime? = null,
 
     var reducido: Int? = null

--- a/src/main/java/um/haberes/core/kotlin/model/Liquidacion.kt
+++ b/src/main/java/um/haberes/core/kotlin/model/Liquidacion.kt
@@ -16,10 +16,10 @@ data class Liquidacion(
     var anho: Int = 0,
     var mes: Int = 0,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaLiquidacion: OffsetDateTime? = null,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaAcreditacion: OffsetDateTime? = null,
 
     var dependenciaId: Int? = null,

--- a/src/main/java/um/haberes/core/kotlin/model/LiquidacionVersion.kt
+++ b/src/main/java/um/haberes/core/kotlin/model/LiquidacionVersion.kt
@@ -17,10 +17,10 @@ data class LiquidacionVersion(
     var mes: Int = 0,
     var version: Int = 0,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaLiquidacion: OffsetDateTime? = null,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaAcreditacion: OffsetDateTime? = null,
 
     var dependenciaId: Int? = null,

--- a/src/main/java/um/haberes/core/kotlin/model/Persona.kt
+++ b/src/main/java/um/haberes/core/kotlin/model/Persona.kt
@@ -16,15 +16,15 @@ data class Persona(
     var apellido: String = "",
     var nombre: String = "",
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var nacimiento: OffsetDateTime? = null,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var altaDocente: OffsetDateTime? = null,
 
     var ajusteDocente: Int = 0,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var altaAdministrativa: OffsetDateTime? = null,
 
     var ajusteAdministrativo: Int = 0,

--- a/src/main/java/um/haberes/core/kotlin/model/Usuario.kt
+++ b/src/main/java/um/haberes/core/kotlin/model/Usuario.kt
@@ -11,7 +11,7 @@ data class Usuario(
     var legajoId: Long? = null,
     var password: String = "",
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var lastLog: OffsetDateTime? = null,
 
     var build: Long? = null,

--- a/src/main/java/um/haberes/core/kotlin/model/extern/CuentaDto.kt
+++ b/src/main/java/um/haberes/core/kotlin/model/extern/CuentaDto.kt
@@ -15,7 +15,7 @@ data class CuentaDto(
     var grado3: BigDecimal? = null,
     var grado4: BigDecimal? = null,
     var geograficaId: Int? = null,
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaBloqueo: OffsetDateTime? = null,
     var visible: Byte = 0,
     var cuentaContableId: Long? = null

--- a/src/main/java/um/haberes/core/kotlin/model/extern/CuentaMovimientoDto.kt
+++ b/src/main/java/um/haberes/core/kotlin/model/extern/CuentaMovimientoDto.kt
@@ -8,7 +8,7 @@ data class CuentaMovimientoDto(
 
     var cuentaMovimientoId: Long? = null,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaContable: OffsetDateTime? = null,
 
     var ordenContable: Int = 0,

--- a/src/main/java/um/haberes/core/kotlin/model/extern/EjercicioDto.kt
+++ b/src/main/java/um/haberes/core/kotlin/model/extern/EjercicioDto.kt
@@ -7,9 +7,9 @@ data class EjercicioDto(
 
     var ejercicioId: Int? = null,
     var nombre: String? = null,
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaInicio: OffsetDateTime? = null,
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaFinal: OffsetDateTime? = null,
     var bloqueado: Byte = 0,
     var ordenContableResultado: Int? = null,

--- a/src/main/java/um/haberes/core/kotlin/model/extern/ProveedorMovimientoDto.kt
+++ b/src/main/java/um/haberes/core/kotlin/model/extern/ProveedorMovimientoDto.kt
@@ -11,10 +11,10 @@ data class ProveedorMovimientoDto(
     var nombreBeneficiario: String = "",
     var comprobanteId: Int? = null,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaComprobante: OffsetDateTime? = null,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaVencimiento: OffsetDateTime? = null,
     var prefijo: Int = 0,
     var numeroComprobante: Long = 0L,
@@ -24,12 +24,12 @@ data class ProveedorMovimientoDto(
     var importe: BigDecimal = BigDecimal.ZERO,
     var cancelado: BigDecimal = BigDecimal.ZERO,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaContable: OffsetDateTime? = null,
     var ordenContable: Int? = null,
     var concepto: String? = null,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaAnulacion: OffsetDateTime? = null,
     var conCargo: Byte = 0,
     var solicitaFactura: Byte = 0,

--- a/src/main/java/um/haberes/core/kotlin/model/internal/OrdenPagoRequest.kt
+++ b/src/main/java/um/haberes/core/kotlin/model/internal/OrdenPagoRequest.kt
@@ -8,7 +8,7 @@ data class OrdenPagoRequest(
 
     var anho: Int? = null,
     var mes: Int? = null,
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaPago: OffsetDateTime? = null,
     var totalSantander: BigDecimal? = null,
     var totalOtrosBancos: BigDecimal? = null,

--- a/src/main/java/um/haberes/core/kotlin/model/view/CargoLiquidacionPeriodo.kt
+++ b/src/main/java/um/haberes/core/kotlin/model/view/CargoLiquidacionPeriodo.kt
@@ -23,10 +23,10 @@ data class CargoLiquidacionPeriodo(
     var mes: Int? = null,
     var dependenciaId: Int? = null,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaDesde: OffsetDateTime? = null,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaHasta: OffsetDateTime? = null,
 
     var categoriaId: Int? = null,

--- a/src/main/java/um/haberes/core/kotlin/model/view/LiquidacionPeriodo.kt
+++ b/src/main/java/um/haberes/core/kotlin/model/view/LiquidacionPeriodo.kt
@@ -19,7 +19,7 @@ data class LiquidacionPeriodo(
     var anho: Int = 0,
     var mes: Int = 0,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaLiquidacion: OffsetDateTime? = null,
 
     var dependenciaId: Int? = null,

--- a/src/main/java/um/haberes/core/kotlin/model/view/PersonaSearch.kt
+++ b/src/main/java/um/haberes/core/kotlin/model/view/PersonaSearch.kt
@@ -19,15 +19,15 @@ data class PersonaSearch(
     var apellido: String = "",
     var nombre: String = "",
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var nacimiento: OffsetDateTime? = null,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var altaDocente: OffsetDateTime? = null,
 
     var ajusteDocente: Int = 0,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var altaAdministrativa: OffsetDateTime? = null,
 
     var ajusteAdministrativo: Int = 0,

--- a/src/main/java/um/haberes/core/service/facade/NovedadFileService.java
+++ b/src/main/java/um/haberes/core/service/facade/NovedadFileService.java
@@ -75,11 +75,11 @@ public class NovedadFileService {
         try {
             InputStream input = new FileInputStream(file);
             Workbook workbook = new XSSFWorkbook(input);
-            Integer sheetCount = workbook.getNumberOfSheets();
-            for (Integer counter = 0; counter < sheetCount; counter++) {
+            int sheetCount = workbook.getNumberOfSheets();
+            for (int counter = 0; counter < sheetCount; counter++) {
                 Sheet sheet = workbook.getSheetAt(counter);
                 log.debug("Sheet -> " + sheet.getSheetName());
-                Integer rows = sheet.getLastRowNum();
+                int rows = sheet.getLastRowNum();
                 Integer cols = (int) sheet.getRow(0).getLastCellNum();
                 Row row = sheet.getRow(0);
                 String columnName = null;
@@ -123,7 +123,7 @@ public class NovedadFileService {
                 }
                 if (columnLegajoId == null || columnCodigoId == null || columnImporte == null)
                     continue;
-                for (Integer rowNumber = 1; rowNumber <= rows; rowNumber++) {
+                for (int rowNumber = 1; rowNumber <= rows; rowNumber++) {
                     Double cellLegajoId = null;
                     Double cellCodigoId = null;
                     Double cellImporte = null;
@@ -143,7 +143,7 @@ public class NovedadFileService {
                     if (columnCodigoId != null)
                         cellCodigoId = row.getCell(columnCodigoId).getNumericCellValue();
                     if (columnImporte != null) {
-                        Boolean testString = true;
+                        boolean testString = true;
                         try {
                             cellImporte = row.getCell(columnImporte).getNumericCellValue();
                             log.debug("Sheet -> " + sheet.getSheetName() + " - Importe -> {}", cellImporte);


### PR DESCRIPTION
## Descripción

Este PR actualiza dependencias del proyecto, corrige la compatibilidad con Java 25 en los modelos y refactoriza `NovedadFileService` para usar tipos primitivos.

## Cambios Realizados

- **chore(deps):** Actualización de Spring Boot 4.0.6 → 4.1.0, Kotlin 2.3.21 → 2.4.0, Spring Cloud 2025.1.0 → 2025.1.2, mysql-connector-j 9.6.0 → 9.7.0, openpdf 3.0.3 → 3.0.5, springdoc 3.0.2 → 3.0.3.
- **fix(model):** Corrección del patrón `@JsonFormat` de `Z` a `XX` en todos los modelos con campos `OffsetDateTime` para compatibilidad con Java 25.
- **refactor(service):** Unboxing de `Integer` a `int` y `Boolean` a `boolean` en `NovedadFileService`.

## Verificación

- [ ] `mvn clean compile` sin errores
- [ ] Pruebas de integración con Java 25
- [ ] Validación de serialización JSON de fechas
